### PR TITLE
Update Native USB function for newer chips

### DIFF
--- a/cpinstaller.js
+++ b/cpinstaller.js
@@ -1389,7 +1389,7 @@ export class CPInstallButton extends InstallButton {
 
     // This is necessary because chips with native USB will have a CIRCUITPY drive, which blocks writing via REPL
     hasNativeUsb() {
-        if (!this.chipFamily || ("esp32", "esp32c3").includes(this.chipFamily)) {
+        if (!this.chipFamily || this.chipFamily == "esp32" || this.chipFamily.startsWith("esp32c")) {
             return false;
         }
 


### PR DESCRIPTION
This wasn't detecting chips such as the ESP32-C6 (see https://github.com/adafruit/circuitpython-org/issues/1695). As far as I can tell, all of the ESP32-C* chips seem to not have native USB, so I'm only comparing that to help future-proof this a bit.