### PR TITLE
Fix issue that prevented language parameter from changing

### DIFF
--- a/cpinstaller.js
+++ b/cpinstaller.js
@@ -162,10 +162,10 @@ export class CPInstallButton extends InstallButton {
                }
                this.releaseVersion = releaseInfo.version;
            }
-           if (releaseInfo.uf2file) {
+           if (releaseInfo.uf2file && !this.uf2FileUrl) {
                this.uf2FileUrl = this.updateBinaryUrl(releaseInfo.uf2file);
            }
-           if (releaseInfo.binfile) {
+           if (releaseInfo.binfile && !this.binFileUrl) {
                this.binFileUrl = this.updateBinaryUrl(releaseInfo.binfile);
            }
        }


### PR DESCRIPTION
This fixes a bit of code that was overwriting the url parameters with the release urls, which were only in english.