### PR TITLE
Update esptool-js version to 0.5.6

### DIFF
--- a/base_installer.js
+++ b/base_installer.js
@@ -5,7 +5,7 @@
 'use strict';
 import {html, render} from 'https://cdn.jsdelivr.net/npm/lit-html/+esm';
 import {asyncAppend} from 'https://cdn.jsdelivr.net/npm/lit-html/directives/async-append/+esm';
-import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.3/bundle.js";
+import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.6/bundle.js";
 export const ESP_ROM_BAUD = 115200;
 
 export class InstallButton extends HTMLButtonElement {


### PR DESCRIPTION
See https://github.com/adafruit/Adafruit_WebSerial_ESPTool/pull/330 and https://github.com/adafruit/Adafruit_WebSerial_ESPTool/issues/328#issuecomment-3954286371

We could also omit the version and just get the latest.