### PR TITLE
fix hardReset error

### DIFF
--- a/base_installer.js
+++ b/base_installer.js
@@ -6,7 +6,7 @@
 import {html, render} from 'https://cdn.jsdelivr.net/npm/lit-html/+esm';
 import {asyncAppend} from 'https://cdn.jsdelivr.net/npm/lit-html/directives/async-append/+esm';
 //import { ESPLoader, Transport } from "https://unpkg.com/esptool-js@0.5.6/bundle.js";
-import { ESPLoader, Transport } from "./bundle.js"; // Latest esptool-js as of 2026-03-17
+import { ESPLoader, Transport, HardReset } from "./bundle.js"; // Latest esptool-js as of 2026-03-17
 export const ESP_ROM_BAUD = 115200;
 
 export class InstallButton extends HTMLButtonElement {
@@ -441,7 +441,7 @@ export class InstallButton extends HTMLButtonElement {
 
     async espHardReset() {
         if (this.esploader) {
-            await this.esploader.hardReset();
+            await new HardReset(this.esploader.transport, false).reset();
         }
     }
 

--- a/cpinstaller.js
+++ b/cpinstaller.js
@@ -459,6 +459,7 @@ export class CPInstallButton extends InstallButton {
             closeable: true,
             template: (data) => html`
                 <p>Successfully Completed</p>
+                <p>If your device doesn't reboot automatically press the reset button once.</p>
                 ${data.ip ?
                     html`<p>
                         You can edit files by going to <a href="http://${data.ip}/code/">http://${data.ip}/code/</a>.


### PR DESCRIPTION
This fixes the hardReset() function not existing console error.
<img width="620" height="314" alt="image" src="https://github.com/user-attachments/assets/d2ea8332-9f7d-4e65-b46b-91529403fe2f" />

hard reset now works as expected on ESP32 based device I used mini sparkle motion for test.

As far as I can tell ESP32-S3 cannot be reset successfully if it was put into rom bootloader mode manually. I added a note to the success dialog message to instruct the user to press the reset button if it doesn't reboot automatically. The "Full Install" workflow for the same S3 device tells the user to manually press reset after tinyuf2 flash is complete. So this makes the "install Bin" workflow contain similar wording after the flash is complete.